### PR TITLE
Don't try to override XDG_CURRENT_DESKTOP

### DIFF
--- a/signal.spec
+++ b/signal.spec
@@ -217,10 +217,10 @@ install -dm755 %{buildroot}%{_datadir}/applications/
 # 1. Run signal WITH sandbox since it looks like there's no problems with fedora and friends
 # 2. Use tray icon by default
 # 3. Small fix for tray for Plasma users
-cat << EOF > %{buildroot}%{_datadir}/applications/signal-desktop.desktop 
+cat << EOF > %{buildroot}%{_datadir}/applications/signal-desktop.desktop
 [Desktop Entry]
 Name=Signal
-Exec=env XDG_CURRENT_DESKTOP=Unity /usr/bin/signal-desktop --use-tray-icon %U
+Exec=/usr/bin/signal-desktop --use-tray-icon %U
 Terminal=false
 Type=Application
 Icon=signal-desktop


### PR DESCRIPTION
I am using your signal-desktop RPM from COPR. I am also using the standard GNOME desktop provided by Fedora. I have a problem where whenever I try to click a URL in a chat window, Signal tries to launch a new Firefox process (instead of creating a new tab in the existing process), and this fails with a dialog about how there's already a Firefox process running. I've narrowed down the fix to this patch.