### PR TITLE
Add missing dependency libXScrnSaver [NOT TESTED]

### DIFF
--- a/signal.spec
+++ b/signal.spec
@@ -1,6 +1,6 @@
 Name:		signal-desktop
 Version:	1.34.5
-Release:	1%{?dist}
+Release:	2%{?dist}
 Summary:	Private messaging from your desktop
 License:	GPLv3
 URL:		https://github.com/signalapp/Signal-Desktop/

--- a/signal.spec
+++ b/signal.spec
@@ -29,7 +29,7 @@ BuildRequires: platform-python-devel, python3
 AutoReqProv: no
 #AutoProv: no
 Provides: signal-desktop
-Requires: GConf2, libnotify, libappindicator-gtk3, libXtst, nss
+Requires: GConf2, libnotify, libappindicator-gtk3, libXtst, nss, libXScrnSaver
 %global __requires_exclude_from ^/%{_libdir}/%{name}/release/.*$
 
 %description


### PR DESCRIPTION
I installed Signal on Fedora (under Qubes OS), but couldn't start it. It complained about missing dependency: `signal-desktop: error while loading shared libraries: libXss.so.1: cannot open shared object file: No such file or directory`.

Installing `sudo dnf install libXScrnSaver` fixed the issue.

How can I test this copr recipe that my change is correct?